### PR TITLE
Choose a name for BrainNetworksInPython

### DIFF
--- a/_posts/blog/2017-09-27-Boaty-McBrainNetworksInPython.md
+++ b/_posts/blog/2017-09-27-Boaty-McBrainNetworksInPython.md
@@ -7,7 +7,7 @@ tags: [brain-networks-in-python, moz-open-leaders]
 image:
   feature:
 link:
-date: 27-09-2017
+date: 06-10-2017
 modified:
 share: true
 author: isla_staden

--- a/_posts/blog/2017-09-27-Boaty-McBrainNetworksInPython.md
+++ b/_posts/blog/2017-09-27-Boaty-McBrainNetworksInPython.md
@@ -3,7 +3,7 @@ layout: post
 title: Boaty-McBrainNetworksInPython
 categories: blog
 excerpt:
-tags: [brain networks in python]
+tags: [brain-networks-in-python, moz-open-leaders]
 image:
   feature:
 link:

--- a/_posts/blog/2017-09-27-Boaty-McBrainNetworksInPython.md
+++ b/_posts/blog/2017-09-27-Boaty-McBrainNetworksInPython.md
@@ -12,9 +12,14 @@ modified:
 share: true
 author: isla_staden
 ---
+<iframe src="https://giphy.com/embed/l41m04gr7tRet7Uas" width="480" height="323" frameBorder="0" class="giphy-embed" allowFullScreen></iframe><p><a href="https://giphy.com/gifs/cute-brain-dance-l41m04gr7tRet7Uas">source</a></p>
 
-The Whitaker Lab has been working on some code currently known as [BrainNetworksInPython](https://github.com/WhitakerLab/BrainNetworksInPython) with the intention to release it as a python package. We'd like to conform to the naming conventions given by [PEP 8 -- Style Guide for Python Code](https://www.python.org/dev/peps/pep-0008/#package-and-module-names):
+The Whitaker Lab has been working on some code currently known as [BrainNetworksInPython](https://github.com/WhitakerLab/BrainNetworksInPython) with the intention to release it as a python package.
+BrainNetworksInPython is a toolkit for conducting analysis on structural covariance networks in the brain. For information on what *that* is, you can check out our [git repo](https://github.com/WhitakerLab/BrainNetworksInPython).
+We'd like to conform to the Python package and module naming conventions given by [PEP 8 -- Style Guide for Python Code](https://www.python.org/dev/peps/pep-0008/#package-and-module-names):
 >Modules should have short, all-lowercase names. Underscores can be used in the module name if it improves readability. Python packages should also have short, all-lowercase names, although the use of underscores is discouraged.
 
-We need a new name: short(ish), all lower case and ideally relevant to what BrainNetworksInPython [does](https://github.com/WhitakerLab/BrainNetworksInPython/blob/master/README.md).  
-If you have ideas or good taste go forth and [vote](https://poll.ly/#/Gx4yMMY7)!
+We need a new name: short(ish), all lower case and ideally relevant to what BrainNetworksInPython [does](https://github.com/WhitakerLab/BrainNetworksInPython/blob/master/README.md). We've thrown a couple of our own suggestions in the hat but we'd really love for you to add your own.
+Have ideas or good taste? Go forth and [vote](https://poll.ly/#/Gx4yMMY7)!
+
+<iframe src="https://giphy.com/embed/EhzWrhGlYuvug" width="480" height="345" frameBorder="0" class="giphy-embed" allowFullScreen></iframe><p><a href="https://giphy.com/gifs/brain-carl-sagan-scientific-literacy-EhzWrhGlYuvug">source</a></p>

--- a/_posts/blog/2017-09-27-Boaty-McBrainNetworksInPython.md
+++ b/_posts/blog/2017-09-27-Boaty-McBrainNetworksInPython.md
@@ -1,0 +1,20 @@
+---
+layout: post
+title:Boaty-McBrainNetworksInPython
+categories: blog
+excerpt:
+tags: [brain networks in python]
+image:
+  feature:
+link:
+date: 27-09-2017
+modified:
+share: true
+author: isla_staden
+---
+
+The Whitaker Lab has been working on some code currently known as [BrainNetworksInPython](https://github.com/WhitakerLab/BrainNetworksInPython) with the intention to release it as a python package. We'd like to conform to the naming conventions given by [PEP 8 -- Style Guide for Python Code](https://www.python.org/dev/peps/pep-0008/#package-and-module-names):
+>Modules should have short, all-lowercase names. Underscores can be used in the module name if it improves readability. Python packages should also have short, all-lowercase names, although the use of underscores is discouraged.
+
+We need a new name: short(ish), all lower case and ideally relevant to what BrainNetworksInPython [does](https://github.com/WhitakerLab/BrainNetworksInPython/blob/master/README.md).  
+If you have ideas or good taste go forth and [vote](https://poll.ly/#/Gx4yMMY7)!

--- a/_posts/blog/2017-09-27-Boaty-McBrainNetworksInPython.md
+++ b/_posts/blog/2017-09-27-Boaty-McBrainNetworksInPython.md
@@ -15,11 +15,12 @@ author: isla_staden
 <iframe src="https://giphy.com/embed/l41m04gr7tRet7Uas" width="480" height="323" frameBorder="0" class="giphy-embed" allowFullScreen></iframe><p><a href="https://giphy.com/gifs/cute-brain-dance-l41m04gr7tRet7Uas">source</a></p>
 
 The Whitaker Lab has been working on some code currently known as [BrainNetworksInPython](https://github.com/WhitakerLab/BrainNetworksInPython) with the intention to release it as a python package.
-BrainNetworksInPython is a toolkit for conducting analysis on structural covariance networks in the brain. For information on what *that* is, you can check out our [git repo](https://github.com/WhitakerLab/BrainNetworksInPython).
-We'd like to conform to the Python package and module naming conventions given by [PEP 8 -- Style Guide for Python Code](https://www.python.org/dev/peps/pep-0008/#package-and-module-names):
+BrainNetworksInPython is an openly developed toolkit for conducting analysis on structural covariance networks in the brain. To learn more you can check out our [GitHub repository](https://github.com/WhitakerLab/BrainNetworksInPython).
+We'd like to conform to the Python package naming conventions given by [PEP 8 -- Style Guide for Python Code](https://www.python.org/dev/peps/pep-0008/#package-and-module-names):
 >Modules should have short, all-lowercase names. Underscores can be used in the module name if it improves readability. Python packages should also have short, all-lowercase names, although the use of underscores is discouraged.
 
-We need a new name: short(ish), all lower case and ideally relevant to what BrainNetworksInPython [does](https://github.com/WhitakerLab/BrainNetworksInPython/blob/master/README.md). We've thrown a couple of our own suggestions (`brainz`, `bnip`, `networknoggins`, `networkbrains` and `brainnetworksinpython`) in the hat but we'd really love for you to add your own.
+We need a new name: short(ish), all lower case and ideally relevant to what BrainNetworksInPython [does](https://github.com/WhitakerLab/BrainNetworksInPython/blob/master/README.md).  
+We've thrown a couple of our own suggestions (`brainz`, `bnip`, `networknoggins`, `networkbrains` and `brainnetworksinpython`) in the hat but we'd really like for you to add your own.  
 Have ideas or good taste? Go forth and [vote](https://poll.ly/#/Gx4yMMY7)!
 
 <iframe src="https://giphy.com/embed/EhzWrhGlYuvug" width="480" height="345" frameBorder="0" class="giphy-embed" allowFullScreen></iframe><p><a href="https://giphy.com/gifs/brain-carl-sagan-scientific-literacy-EhzWrhGlYuvug">source</a></p>

--- a/_posts/blog/2017-09-27-Boaty-McBrainNetworksInPython.md
+++ b/_posts/blog/2017-09-27-Boaty-McBrainNetworksInPython.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-title:Boaty-McBrainNetworksInPython
+title: Boaty-McBrainNetworksInPython
 categories: blog
 excerpt:
 tags: [brain networks in python]

--- a/_posts/blog/2017-09-27-Boaty-McBrainNetworksInPython.md
+++ b/_posts/blog/2017-09-27-Boaty-McBrainNetworksInPython.md
@@ -19,7 +19,7 @@ BrainNetworksInPython is a toolkit for conducting analysis on structural covaria
 We'd like to conform to the Python package and module naming conventions given by [PEP 8 -- Style Guide for Python Code](https://www.python.org/dev/peps/pep-0008/#package-and-module-names):
 >Modules should have short, all-lowercase names. Underscores can be used in the module name if it improves readability. Python packages should also have short, all-lowercase names, although the use of underscores is discouraged.
 
-We need a new name: short(ish), all lower case and ideally relevant to what BrainNetworksInPython [does](https://github.com/WhitakerLab/BrainNetworksInPython/blob/master/README.md). We've thrown a couple of our own suggestions in the hat but we'd really love for you to add your own.
+We need a new name: short(ish), all lower case and ideally relevant to what BrainNetworksInPython [does](https://github.com/WhitakerLab/BrainNetworksInPython/blob/master/README.md). We've thrown a couple of our own suggestions (`brainz`, `bnip`, `networknoggins`, `networkbrains` and `brainnetworksinpython`) in the hat but we'd really love for you to add your own.
 Have ideas or good taste? Go forth and [vote](https://poll.ly/#/Gx4yMMY7)!
 
 <iframe src="https://giphy.com/embed/EhzWrhGlYuvug" width="480" height="345" frameBorder="0" class="giphy-embed" allowFullScreen></iframe><p><a href="https://giphy.com/gifs/brain-carl-sagan-scientific-literacy-EhzWrhGlYuvug">source</a></p>

--- a/_posts/blog/2017-09-27-Boaty-McBrainNetworksInPython.md
+++ b/_posts/blog/2017-09-27-Boaty-McBrainNetworksInPython.md
@@ -2,7 +2,7 @@
 layout: post
 title: Boaty-McBrainNetworksInPython
 categories: blog
-excerpt:
+excerpt: Help us choose a new name for our brain networks software package
 tags: [brain-networks-in-python, moz-open-leaders]
 image:
   feature:
@@ -12,15 +12,30 @@ modified:
 share: true
 author: isla_staden
 ---
-<iframe src="https://giphy.com/embed/l41m04gr7tRet7Uas" width="480" height="323" frameBorder="0" class="giphy-embed" allowFullScreen></iframe><p><a href="https://giphy.com/gifs/cute-brain-dance-l41m04gr7tRet7Uas">source</a></p>
+
+## Help us [choose a new name](https://poll.ly/#/Gx4yMMY7) for our brain networks software package
+
+<figure>
+	<img src="https://media.giphy.com/media/l41m04gr7tRet7Uas/giphy.gif" alt="dancing brain">
+	<figcaption>Source: <a href="http://ucresearch.tumblr.com/post/42378715856/the-grateful-brain-uclas-alex-korb-takes-a-look">University of California</a> via Giphy.</figcaption>
+</figure>
 
 The Whitaker Lab has been working on some code currently known as [BrainNetworksInPython](https://github.com/WhitakerLab/BrainNetworksInPython) with the intention to release it as a python package.
+
 BrainNetworksInPython is an openly developed toolkit for conducting analysis on structural covariance networks in the brain. To learn more you can check out our [GitHub repository](https://github.com/WhitakerLab/BrainNetworksInPython).
 We'd like to conform to the Python package naming conventions given by [PEP 8 -- Style Guide for Python Code](https://www.python.org/dev/peps/pep-0008/#package-and-module-names):
+
 >Modules should have short, all-lowercase names. Underscores can be used in the module name if it improves readability. Python packages should also have short, all-lowercase names, although the use of underscores is discouraged.
 
-We need a new name: short(ish), all lower case and ideally relevant to what BrainNetworksInPython [does](https://github.com/WhitakerLab/BrainNetworksInPython/blob/master/README.md).  
-We've thrown a couple of our own suggestions (`brainz`, `bnip`, `networknoggins`, `networkbrains` and `brainnetworksinpython`) in the hat but we'd really like for you to add your own.  
-Have ideas or good taste? Go forth and [vote](https://poll.ly/#/Gx4yMMY7)!
+**We need a new name**: short(ish), all lower case and ideally relevant to what BrainNetworksInPython [does](https://github.com/WhitakerLab/BrainNetworksInPython/blob/master/README.md).  
 
-<iframe src="https://giphy.com/embed/EhzWrhGlYuvug" width="480" height="345" frameBorder="0" class="giphy-embed" allowFullScreen></iframe><p><a href="https://giphy.com/gifs/brain-carl-sagan-scientific-literacy-EhzWrhGlYuvug">source</a></p>
+We've thrown a couple of our own suggestions (`brainz`, `bnip`, `networknoggins`, `networkbrains` and `brainnetworksinpython`) in the hat but we'd really like for you to add your own.  
+
+**Have ideas or good taste?** Go forth and vote at [https://poll.ly/#/Gx4yMMY7](https://poll.ly/#/Gx4yMMY7)!
+
+Thank you!
+
+<figure>
+	<img src="https://media.giphy.com/media/EhzWrhGlYuvug/giphy.gif" alt="carl sagan: journey starts here">
+	<figcaption>Source <a href="http://electricspacekoolaid.tumblr.com/post/53993308420">Electric Space Kool Aid</a> via Giphy.</figcaption>
+</figure>


### PR DESCRIPTION
This is the blog suggested in https://github.com/WhitakerLab/BrainNetworksInPython/issues/19. I think it's best to (begin to) address https://github.com/WhitakerLab/BrainNetworksInPython/issues/18 before merging. That way people can check the readme to see what they're voting over :nail_care: . 

Meanwhile, see what you think :woman_cartwheeling: 