### PR TITLE
Tweaks

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -41,7 +41,7 @@ identifier = "home"
 url = "/"
 
 [[menu.main]]
-name = "About"
+name = "About Us"
 weight = 200
 identifier = "about"
 url = "/about/"

--- a/content/contact.md
+++ b/content/contact.md
@@ -17,5 +17,5 @@ You may be able to help us out!
 
 We have a [gitter chat room](https://gitter.im/WhitakerLab/Lobby) and love to say hello there.
 
-This website is hosted via [GitHub pages](https://github.com/WhitakerLab/whitakerlab.github.io).
+This website is built from [GitHub](https://github.com/WhitakerLab/whitakerlab.github.io).
 If you see any typos or other mistakes please let us know... or file a pull request with your edits.


### PR DESCRIPTION
Change the title of "About" page to "About Us" so that it's clearer that page will contain details about the members of the Lab